### PR TITLE
use contact data from entry profiles

### DIFF
--- a/CsvReader/CsvReader.csproj
+++ b/CsvReader/CsvReader.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>  
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.5.0" />
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.10.0" />
   </ItemGroup>
 
 </Project>

--- a/CsvReader/CsvReader.csproj
+++ b/CsvReader/CsvReader.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>  
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.12.0" />
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.12.0-new-contact-details" />
   </ItemGroup>
 
 </Project>

--- a/CsvReader/CsvReader.csproj
+++ b/CsvReader/CsvReader.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>  
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.10.0" />
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.12.0" />
   </ItemGroup>
 
 </Project>

--- a/CsvReader/CsvReader.csproj
+++ b/CsvReader/CsvReader.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>  
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.12.0-new-contact-details" />
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.12.0" />
   </ItemGroup>
 
 </Project>

--- a/CsvReader/Domain/UcasInstitutionProfile.cs
+++ b/CsvReader/Domain/UcasInstitutionProfile.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GovUk.Education.ManageCourses.Csv.Domain
+{
+    /// <summary>
+    /// Used to get the data from the csv file. Maps property names to the field names
+    /// </summary>
+    public class UcasInstitutionProfile
+    {
+        public string inst_code { get; set; }	
+        public string inst_code_alpha { get; set; }	
+        public string inst_name { get; set; }	
+        public string inst_person { get; set; }	
+        public string inst_job { get; set; }	
+        public string inst_address1 { get; set; }	
+        public string inst_address2 { get; set; }	
+        public string inst_address3 { get; set; }	
+        public string inst_address4 { get; set; }
+        public string inst_post_code { get; set; }
+        public string inst_tel { get; set; }
+        public string inst_fax { get; set; }
+        public string region_code { get; set; }
+        public string map_ref { get; set; }	
+        public string primary_intake { get; set; }
+        public string middle_intake { get; set; }
+        public string secondary_intake { get; set; }
+        public string further_ed { get; set; }
+        public string coll_desc { get; set; }
+        public string web_addr { get; set; }
+        public string filenamey { get; set; }
+        public string email { get; set; }
+        public string scitt { get; set; }
+    }
+}

--- a/src/importer/DownloaderAndExtractor.cs
+++ b/src/importer/DownloaderAndExtractor.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using Serilog.Core;
+
+namespace GovUk.Education.ManageCourses.UcasCourseImporter
+{
+    internal class DownloaderAndExtractor
+    {
+        private readonly Logger logger;
+        private readonly string workingDirectory;
+        private readonly UcasZipDownloader ucasZipDownloader;
+        private readonly UcasZipExtractor extractor;
+
+        public DownloaderAndExtractor(Logger logger, string workingDirectory, string azureUrl, string azureSignature)
+        {
+            this.logger = logger;
+            this.workingDirectory = workingDirectory;
+            this.ucasZipDownloader = new UcasZipDownloader(logger, azureUrl, azureSignature);
+            this.extractor = new UcasZipExtractor();
+        }
+
+        public string DownloadAndExtractLatest(string prefix)
+        {
+            var zipFile = ucasZipDownloader.DownloadLatestToFolder(workingDirectory, prefix).Result;
+            var unzipFolder = Path.Combine(workingDirectory, prefix);
+            logger.Information($"Unzipping {zipFile} to {unzipFolder}");
+            extractor.Extract(zipFile, unzipFolder);
+            return unzipFolder;
+        }
+    }
+}

--- a/src/importer/Program.cs
+++ b/src/importer/Program.cs
@@ -101,6 +101,8 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter
                     inst.Addr4 = profile.inst_address4.Trim();
                     inst.Postcode = profile.inst_post_code.Trim();
                     inst.ContactName = profile.inst_person.Trim();
+                    inst.Email = profile.email.Trim();
+                    inst.Telephone = profile.inst_tel.Trim();
                     inst.Url = profile.web_addr.Trim();
                 }
             }

--- a/src/importer/UcasCourseImporter.csproj
+++ b/src/importer/UcasCourseImporter.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NSwag.MSBuild" Version="11.17.13" />
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.10.0" />
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.12.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="2.6.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/src/importer/UcasCourseImporter.csproj
+++ b/src/importer/UcasCourseImporter.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NSwag.MSBuild" Version="11.17.13" />
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.12.0" />
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.12.0-new-contact-details" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="2.6.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/src/importer/UcasCourseImporter.csproj
+++ b/src/importer/UcasCourseImporter.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NSwag.MSBuild" Version="11.17.13" />
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.12.0-new-contact-details" />
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.12.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="2.6.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/src/importer/UcasCourseImporter.csproj
+++ b/src/importer/UcasCourseImporter.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NSwag.MSBuild" Version="11.17.13" />
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.8.0.1" />
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.10.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="2.6.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/src/importer/UcasZipDownloader.cs
+++ b/src/importer/UcasZipDownloader.cs
@@ -25,7 +25,7 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter
             _sharedAccessSignatureQueryString = sharedAccessSignature;
         }
 
-        public async Task<string> DownloadLatestToFolder(string folder)
+        public async Task<string> DownloadLatestToFolder(string folder, string prefix)
         {
 
             // list files
@@ -35,7 +35,7 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter
             var list = XElement.Parse(await listResponse.Content.ReadAsStringAsync());
 
             var filenames = new List<AzureFile>();
-            const string fileNameRegexString = "^NetupdateExtract_([0-9]{2})([0-9]{2})([0-9]{4})_([0-9]{2})([0-9]{2})\\.zip$";
+            var fileNameRegexString = "^" + prefix + "_([0-9]{2})([0-9]{2})([0-9]{4})_([0-9]{2})([0-9]{2})\\.zip$";
             var fileNameRegex = new Regex(fileNameRegexString);
             
             foreach (var blobElement in list.Element("Blobs").Elements())
@@ -67,7 +67,7 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter
             }
 
             // download best file
-            string fileToWriteTo = Path.Combine(folder, "ucas-data.zip");
+            string fileToWriteTo = Path.Combine(folder, $"{prefix}.zip");
 
             _logger.Information($"Downloading {bestFileName} to {fileToWriteTo}");
 

--- a/src/xls-reader/XlsReader.csproj
+++ b/src/xls-reader/XlsReader.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>  
 
   <ItemGroup>  
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.8.0.1" />  
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.10.0" />  
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
   

--- a/src/xls-reader/XlsReader.csproj
+++ b/src/xls-reader/XlsReader.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>  
 
   <ItemGroup>  
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.12.0-new-contact-details" />  
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.12.0" />  
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
   

--- a/src/xls-reader/XlsReader.csproj
+++ b/src/xls-reader/XlsReader.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>  
 
   <ItemGroup>  
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.12.0" />  
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.12.0-new-contact-details" />  
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
   

--- a/src/xls-reader/XlsReader.csproj
+++ b/src/xls-reader/XlsReader.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>  
 
   <ItemGroup>  
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.10.0" />  
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.12.0" />  
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
   


### PR DESCRIPTION
## Context

https://trello.com/b/fXA6ioZN/find-teacher-training-team-board

## Proposed changes

- split out the "download and extract" flow, which now has to happen twice for two zip files, into a class and invoke it twice
- Read the gttr_inst.csv from EntryProfiles
- Override contact data from NetupdateExtract with contact data from EntryProfiles before sending the payload

